### PR TITLE
remove magic number of data store percentage and correct some spell errors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014, Bluebore
+Copyright (c) 2015, Baidu.inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -79,8 +79,9 @@ DEFINE_int32(chunkserver_file_cache_size, 1000, "Chunkserver file cache size");
 DEFINE_int32(chunkserver_use_root_partition, 1, "Should chunkserver use root partition, 0: forbidden");
 DEFINE_bool(chunkserver_multi_path_on_one_disk, false, "Allow multi data path on one disk");
 DEFINE_bool(chunkserver_auto_clean, true, "If namespace version mismatch, chunkserver clean itself");
-DEFINE_int32(chunkserver_disk_buf_size, 100, "Base number of buffers which are in the waiting list. Used to computer disk wordload");
-DEFINE_int64(chunkserver_disk_safe_space, 5120, "If space left on a disk is less then this value, the disk will be concidered full. In MB");
+DEFINE_int32(chunkserver_disk_buf_size, 100, "Base number of buffers which are in the waiting list. Used to computer disk workload");
+DEFINE_int64(chunkserver_disk_safe_space, 5120, "If space left on a disk is less then this value, the disk will be considered full. In MB");
+DEFINE_int32(chunkserver_disk_data_store_limit_percent, 95, "If the percentage of data stored on a disk is larger than this value, the disk will be considered full. E.g. 95 means 95 percent");
 // SDK
 DEFINE_string(sdk_write_mode, "fanout", "Sdk write strategy, choose from [chains, fanout]");
 DEFINE_int32(sdk_thread_num, 10, "Sdk thread num");

--- a/src/nameserver/chunkserver_manager.cc
+++ b/src/nameserver/chunkserver_manager.cc
@@ -15,6 +15,7 @@
 
 DECLARE_int32(keepalive_timeout);
 DECLARE_int32(chunkserver_max_pending_buffers);
+DECLARE_int32(chunkserver_disk_data_store_limit_percent);
 DECLARE_int32(recover_speed);
 DECLARE_int32(recover_dest_limit);
 DECLARE_int32(heartbeat_interval);
@@ -335,7 +336,9 @@ double ChunkServerManager::GetChunkServerLoad(ChunkServerInfo* cs) {
     double data_score = cs->data_size() * 1.0 / cs->disk_quota();
     int64_t space_left = cs->disk_quota() - cs->data_size();
 
-    if (data_score > 0.95 || space_left < (5L << 30) || pending_score > 1.0) {
+    if (data_score > FLAGS_chunkserver_disk_data_store_limit_percent * 1.0 / 100
+            || space_left < (5L << 30)
+            || pending_score > 1.0) {
         return 1.0;
     }
     return (data_score * data_score + pending_score) / 2;


### PR DESCRIPTION
(#901)
    add a flag of chunkserver_disk_data_store_limit_percent in flags.cc
    correct some spell errors in flags.cc

(line 82, 83 in flags.cc).
the disk will be concidered full. considered
Used to computer disk wordload : workload